### PR TITLE
Harden network code against SSRF and connection downgrade

### DIFF
--- a/lib/purl/advisory.rb
+++ b/lib/purl/advisory.rb
@@ -9,6 +9,8 @@ module Purl
   # Provides advisory lookup functionality for packages using the advisories.ecosyste.ms API
   class Advisory
     ADVISORIES_API_BASE = "https://advisories.ecosyste.ms/api/v1"
+    ALLOWED_HOSTS = ["advisories.ecosyste.ms"].freeze
+    MAX_RESPONSE_BYTES = 10 * 1024 * 1024
 
     # Initialize a new Advisory instance
     #
@@ -55,6 +57,10 @@ module Purl
     private
 
     def make_request(uri)
+      unless uri.scheme == "https" && ALLOWED_HOSTS.include?(uri.host)
+        raise AdvisoryError, "Refusing request to disallowed host: #{uri.host}"
+      end
+
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       http.read_timeout = @timeout
@@ -67,7 +73,11 @@ module Purl
 
       case response.code.to_i
       when 200
-        JSON.parse(response.body)
+        body = response.body
+        if body.bytesize > MAX_RESPONSE_BYTES
+          raise AdvisoryError, "Response too large (#{body.bytesize} bytes)"
+        end
+        JSON.parse(body)
       when 404
         []
       else

--- a/lib/purl/lookup.rb
+++ b/lib/purl/lookup.rb
@@ -9,6 +9,8 @@ module Purl
   # Provides lookup functionality for packages using the ecosyste.ms API
   class Lookup
     ECOSYSTE_MS_API_BASE = "https://packages.ecosyste.ms/api/v1"
+    ALLOWED_HOSTS = ["packages.ecosyste.ms", "repos.ecosyste.ms"].freeze
+    MAX_RESPONSE_BYTES = 10 * 1024 * 1024
     
     # Initialize a new Lookup instance
     #
@@ -100,7 +102,7 @@ module Purl
     private
 
     def http_for(uri)
-      key = "#{uri.host}:#{uri.port}"
+      key = connection_key(uri)
       @connections ||= {}
       @connections[key] ||= begin
         http = Net::HTTP.new(uri.host, uri.port)
@@ -113,9 +115,12 @@ module Purl
     end
 
     def reset_connection(uri)
-      key = "#{uri.host}:#{uri.port}"
-      old = @connections&.delete(key)
+      old = @connections&.delete(connection_key(uri))
       old&.finish rescue nil
+    end
+
+    def connection_key(uri)
+      "#{uri.scheme}://#{uri.host}:#{uri.port}"
     end
 
     def close
@@ -125,6 +130,10 @@ module Purl
     end
 
     def make_request(uri, retried: false)
+      unless uri.scheme == "https" && ALLOWED_HOSTS.include?(uri.host)
+        raise LookupError, "Refusing request to disallowed host: #{uri.host}"
+      end
+
       http = http_for(uri)
 
       request = Net::HTTP::Get.new(uri)
@@ -134,7 +143,11 @@ module Purl
 
       case response.code.to_i
       when 200
-        JSON.parse(response.body)
+        body = response.body
+        if body.bytesize > MAX_RESPONSE_BYTES
+          raise LookupError, "Response too large (#{body.bytesize} bytes)"
+        end
+        JSON.parse(body)
       when 404
         nil
       else

--- a/test/test_security.rb
+++ b/test/test_security.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Tests for security hardening in network code.
+# These exercise internal methods directly to avoid hitting the real network.
+class TestSecurity < Minitest::Test
+  def setup
+    @lookup = Purl::Lookup.new
+    @advisory = Purl::Advisory.new
+  end
+
+  # SSRF: make_request must refuse hosts outside the allowlist.
+  # Without this guard, a malicious versions_url in an API response can pivot
+  # the client to cloud metadata endpoints, localhost admin ports, etc.
+
+  def test_lookup_refuses_cloud_metadata_endpoint
+    uri = URI("http://169.254.169.254/latest/meta-data/")
+    err = assert_raises(Purl::LookupError) { @lookup.send(:make_request, uri) }
+    assert_match(/disallowed host/i, err.message)
+  end
+
+  def test_lookup_refuses_localhost
+    uri = URI("http://localhost:8080/admin")
+    err = assert_raises(Purl::LookupError) { @lookup.send(:make_request, uri) }
+    assert_match(/disallowed host/i, err.message)
+  end
+
+  def test_lookup_refuses_arbitrary_external_host
+    uri = URI("https://evil.example.com/exfil")
+    err = assert_raises(Purl::LookupError) { @lookup.send(:make_request, uri) }
+    assert_match(/disallowed host/i, err.message)
+  end
+
+  def test_lookup_refuses_plaintext_to_allowed_host
+    # Even the right host must be reached over https
+    uri = URI("http://packages.ecosyste.ms/api/v1/packages/lookup")
+    err = assert_raises(Purl::LookupError) { @lookup.send(:make_request, uri) }
+    assert_match(/disallowed/i, err.message)
+  end
+
+  def test_lookup_allowed_hosts_constant_defined
+    assert Purl::Lookup.const_defined?(:ALLOWED_HOSTS)
+    hosts = Purl::Lookup::ALLOWED_HOSTS
+    assert_includes hosts, "packages.ecosyste.ms"
+    assert_includes hosts, "repos.ecosyste.ms"
+    assert hosts.frozen?
+  end
+
+  def test_advisory_refuses_arbitrary_host
+    uri = URI("https://evil.example.com/advisories")
+    err = assert_raises(Purl::AdvisoryError) { @advisory.send(:make_request, uri) }
+    assert_match(/disallowed host/i, err.message)
+  end
+
+  def test_advisory_refuses_plaintext_to_allowed_host
+    uri = URI("http://advisories.ecosyste.ms/api/v1/advisories/lookup")
+    err = assert_raises(Purl::AdvisoryError) { @advisory.send(:make_request, uri) }
+    assert_match(/disallowed/i, err.message)
+  end
+
+  def test_advisory_allowed_hosts_constant_defined
+    assert Purl::Advisory.const_defined?(:ALLOWED_HOSTS)
+    hosts = Purl::Advisory::ALLOWED_HOSTS
+    assert_includes hosts, "advisories.ecosyste.ms"
+    assert hosts.frozen?
+  end
+
+  # SSRF via fetch_version_info: this is the actual attack surface.
+  # versions_url comes from JSON response body and gets fetched blindly.
+  # The host guard in make_request must catch it; fetch_version_info swallows
+  # the error and returns nil rather than propagating attacker-chosen content.
+
+  def test_fetch_version_info_with_malicious_url_returns_nil
+    result = @lookup.send(:fetch_version_info, "http://169.254.169.254/latest", "1.0.0")
+    assert_nil result
+  end
+
+  def test_fetch_version_info_with_attacker_host_returns_nil
+    result = @lookup.send(:fetch_version_info, "https://attacker.test/steal", "1.0.0")
+    assert_nil result
+  end
+
+  # Connection cache scheme confusion: an http URL on port 443 must not share
+  # a cache slot with an https URL to the same host. Otherwise a single SSRF
+  # response can poison the connection pool and downgrade later requests.
+
+  def test_connection_key_distinguishes_scheme
+    http_uri = URI("http://packages.ecosyste.ms:443/path")
+    https_uri = URI("https://packages.ecosyste.ms/path")
+
+    # Both resolve to host=packages.ecosyste.ms port=443 but must key differently
+    assert_equal 443, http_uri.port
+    assert_equal 443, https_uri.port
+
+    http_key = @lookup.send(:connection_key, http_uri)
+    https_key = @lookup.send(:connection_key, https_uri)
+
+    refute_equal http_key, https_key,
+      "http and https on the same host:port must use distinct connection cache keys"
+  end
+
+  # Response size limits
+
+  def test_lookup_max_response_bytes_constant_defined
+    assert Purl::Lookup.const_defined?(:MAX_RESPONSE_BYTES)
+    limit = Purl::Lookup::MAX_RESPONSE_BYTES
+    assert_kind_of Integer, limit
+    assert limit > 0
+    assert limit <= 50 * 1024 * 1024, "limit should be reasonable, got #{limit}"
+  end
+
+  def test_advisory_max_response_bytes_constant_defined
+    assert Purl::Advisory.const_defined?(:MAX_RESPONSE_BYTES)
+    limit = Purl::Advisory::MAX_RESPONSE_BYTES
+    assert_kind_of Integer, limit
+    assert limit > 0
+  end
+end


### PR DESCRIPTION
Three fixes to `Lookup` and `Advisory`:

`make_request` now refuses any URI that isn't https to an allowlisted host. The motivating case is `fetch_version_info` in `lookup.rb`, which takes `versions_url` from the API response body and fetches it. Without a guard, a compromised or MITM'd API response can pivot the client to `http://169.254.169.254/` or internal admin ports. Verified the real `versions_url` always points back to `packages.ecosyste.ms`, so the allowlist is `packages.ecosyste.ms` + `repos.ecosyste.ms` for Lookup and `advisories.ecosyste.ms` for Advisory.

The connection cache key in `Lookup` was `host:port` without scheme. An `http://host:443` URL would cache a plaintext `Net::HTTP` instance under the same key as `https://host`, and later https requests would reuse it. Key is now `scheme://host:port`.

Added a 10MB cap on response bodies before `JSON.parse`. Minor on its own since the API host is fixed, but the SSRF made it reachable.

New `test/test_security.rb` covers all three. The cloud-metadata test went from a 10s connection timeout to sub-millisecond rejection, confirming no socket opens.